### PR TITLE
Add DefaultSignatures

### DIFF
--- a/Kmett.hs
+++ b/Kmett.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MonoLocalBinds #-} -- Kills a warning in 8.2
 module Kmett where
 
 import Prelude hiding ((.), id, Functor(fmap))

--- a/kinder-functor.cabal
+++ b/kinder-functor.cabal
@@ -12,7 +12,7 @@ cabal-version: >=1.10
 library
   exposed-modules: Kinder.Functor
   other-modules: Kmett
-  build-depends: base >=4.9 && <4.10
+  build-depends: base >=4.10 && <4.11
                , markdown-unlit >=0.4.0 && <0.5
                , constraints >=0.9.1 && <0.10
   default-language: Haskell2010


### PR DESCRIPTION
It's actually possible to use `DefaultSignatures`, in a slightly
different way than you did. You need to use heterogeneous equality
(`(~~)`) rather than homogeneous (`(~)`), and (as will generally
be the case) you need to make the default signature the same as
the actual signature except for constraints. Unfortunately, GHC
8.0.2 panics with the code I've written; it compiles in a recent
8.2.

**Note: you may wish to use CPP to enable this to compile with 8.0.2**